### PR TITLE
remove redundant nibble traversal for extensions when verifying a proof

### DIFF
--- a/contracts/MerklePatriciaProof.sol
+++ b/contracts/MerklePatriciaProof.sol
@@ -59,10 +59,6 @@ library MerklePatriciaProof {
                         return false;
                     }
                 }
-                //extension node
-                if(_nibblesToTraverse(RLP.toData(currentNodeList[0]), path, pathPtr) == 0) {
-                    return false;
-                }
 
                 nodeKey = RLP.toBytes32(currentNodeList[1]);
             } else {


### PR DESCRIPTION
## Problem

The [verify function](https://github.com/ConsenSysMesh/rb-relay/blob/master/contracts/MerklePatriciaProof.sol#L19-L72) of the [MerklePatriciaProof.sol](https://github.com/ConsenSysMesh/rb-relay/blob/master/contracts/MerklePatriciaProof.sol) smart contract does not process extensions correctly.

## Problem Specifics
In lines [62-65](https://github.com/ConsenSysMesh/rb-relay/blob/master/contracts/MerklePatriciaProof.sol#L62-L65) it checks if there is an extension at pathPtr. But, since pathPtr was already incremented in line [53](https://github.com/ConsenSysMesh/rb-relay/blob/4043a0bf22dbe8f896cd9b03861492adbdfa8091/contracts/MerklePatriciaProof.sol#L53), it can never detect an extension.

## Solution
Remove lines [62-65](https://github.com/ConsenSysMesh/rb-relay/blob/master/contracts/MerklePatriciaProof.sol#L62-L65) since we just traverse an extension and want to check for the next nibble.